### PR TITLE
Add dockerize version for wheezy

### DIFF
--- a/docker/wheezy/Dockerfile
+++ b/docker/wheezy/Dockerfile
@@ -1,0 +1,22 @@
+FROM debian:7.7
+
+RUN apt-get update && \
+	apt-get install -y \
+    curl \
+		debhelper \
+    libasound2 \
+    libxi6 \
+    libxrender1\
+    libxt6 \
+    libxtst6 \
+    lsb-release \
+    unixodbc \
+    unzip \
+    zip
+
+RUN git clone git://github.com/rraptorr/oracle-java8.git && \
+  cd oracle-java8 && \
+  ./prepare.sh && \
+  dpkg-buildpackage -uc -us && \
+  cd .. && \
+  zip oracle-java8.zip *.deb

--- a/docker/wheezy/README.md
+++ b/docker/wheezy/README.md
@@ -1,0 +1,13 @@
+# Build Debian Java8 via Docker
+
+Use docker to build Java8 Debian packages for Debian Wheezy (7.7)
+
+    sudo docker build -t java8-deb .
+    sudo docker run --rm -i java8-deb cat oracle-java8.zip > oracle-java8.zip
+    sudo docker rmi java8-deb
+
+Extract packages from `java8-deb.zip` and install them on your system
+
+    sudo apt-get install java-common locales
+    unzip oracle-java8.zip
+    sudo dpkg -i oracle-java8-bin_8*.deb oracle-java8-fonts_8.*.deb oracle-java8-jre_8.*.deb


### PR DESCRIPTION
I added a dockerized version to build Debian wheezy package for Java8. This could be easily extended to other Debian versions