### PR TITLE
Provides java8-sdk and java7-sdk

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -69,7 +69,7 @@ Package: oracle-java8-jdk
 Architecture: amd64 i386
 Depends: oracle-java8-bin (>= ${source:Version}), ${shlibs:Depends}, ${misc:Depends}
 Suggests: default-jdk-doc, oracle-java8-source
-Provides: java-compiler, java2-compiler, java-sdk, java2-sdk, java5-sdk, java6-sdk, java7-jdk, java8-jdk
+Provides: java-compiler, java2-compiler, java-sdk, java2-sdk, java5-sdk, java6-sdk, java7-jdk, java7-sdk, java8-jdk, java8-sdk
 Description: Oracle Java(TM) Development Kit (JDK) 8
  The JDK(TM) is a development environment for building applications, 
  applets, and components using the Java programming language.


### PR DESCRIPTION
OpenJDK packages from Debian/Ubuntu are providing `java8-sdk`, not `java8-jdk`. Therefore, add it to the list of provided packages. Keep `java8-jdk` in case people rely on this too.