### PR TITLE
unixodbc libpango1.0-0 need to be installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Usage
 
 To create packages on your own:
 
-- apt-get install debhelper
+- apt install debhelper unixodbc libpango1.0-0
 - git clone git://github.com/rraptorr/oracle-java8.git
 - cd oracle-java8
 - download jdk-8u221-linux-x64.tar.gz and jdk-8u221-linux-i586.tar.gz


### PR DESCRIPTION
1) unixodbc libpango1.0-0 need to be installed to create debian package
2) apt is more preferred then apt-get